### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@
 #     steps:
 #     - uses: actions/checkout@master
 #     - name: Publish to Docker Repository
-#       uses: elgohr/Publish-Docker-Github-Action@master
+#       uses: elgohr/Publish-Docker-Github-Action@v5
 #       with:
 #         name: 1204745933/github-myfile-action
 #         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore